### PR TITLE
Improve Git-backed registry editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ REGISTRY_BACKEND_GIT_REMOTE_URL | git remote URL used to bootstrap a clone when 
 REGISTRY_BACKEND_GIT_BRANCH | branch used for fetch/push operations. | `main`
 REGISTRY_BACKEND_GIT_FETCH_TTL_SECONDS | read-side fetch freshness window; writes always refresh first. | `30`
 REGISTRY_BACKEND_GIT_AUTHOR_NAME | commit author name for registry-managed writes. | `briceburg`
-REGISTRY_BACKEND_GIT_AUTHOR_EMAIL | commit author email for registry-managed writes. Use a GitHub-linked address (for example a GitHub noreply email) if you want github.com to attribute commits to your account. | `briceburg@users.noreply.github.com`
+REGISTRY_BACKEND_GIT_AUTHOR_EMAIL | commit author email for registry-managed writes. Use a GitHub-linked address (for example a GitHub noreply email) if you want GitHub to attribute commits to your account. | `briceburg@users.noreply.github.com`
 REGISTRY_BACKEND_GIT_SSH_KEY_PATH | optional SSH private key path for deploy-key authentication. | `None`
 REGISTRY_BIND_HOST | host to bind to | `localhost`
 REGISTRY_BIND_PORT | port to bind to | `8000`

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ The intended authentication model is a write-enabled GitHub deploy key over SSH.
 
 The checked-in `fly.toml` uses `tmp/data` as the local checkout. The backend also uses a repo-scoped file lock so processes sharing the same checkout serialize Git operations safely.
 
-Deploy by creating a write-enabled GitHub deploy key for the data repo, storing its private key in the Fly secret `REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY`, and then deploying:
+Deploy by generating an SSH keypair, adding the **public** key to the data repo as a write-enabled GitHub deploy key, storing the **private** key in the Fly secret `REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY`, and then deploying:
 
 ```sh
 ssh-keygen -t ed25519 -f ~/.ssh/radio-pad-registry-data-fly -C "radio-pad-registry fly deploy"
+# add ~/.ssh/radio-pad-registry-data-fly.pub to GitHub as a deploy key with write access
 fly secrets set REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY="$(cat ~/.ssh/radio-pad-registry-data-fly)"
 fly deploy
 curl -i https://radio-pad-registry.fly.dev/healthz

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ REGISTRY_BACKEND_GIT_REMOTE_URL | git remote URL used to bootstrap a clone when 
 REGISTRY_BACKEND_GIT_BRANCH | branch used for fetch/push operations. | `main`
 REGISTRY_BACKEND_GIT_FETCH_TTL_SECONDS | read-side fetch freshness window; writes always refresh first. | `30`
 REGISTRY_BACKEND_GIT_AUTHOR_NAME | commit author name for registry-managed writes. | `briceburg`
-REGISTRY_BACKEND_GIT_AUTHOR_EMAIL | commit author email for registry-managed writes. | `briceburg@users.noreply.github.com`
+REGISTRY_BACKEND_GIT_AUTHOR_EMAIL | commit author email for registry-managed writes. Use a GitHub-linked address (for example a GitHub noreply email) if you want github.com to attribute commits to your account. | `briceburg@users.noreply.github.com`
 REGISTRY_BACKEND_GIT_SSH_KEY_PATH | optional SSH private key path for deploy-key authentication. | `None`
 REGISTRY_BIND_HOST | host to bind to | `localhost`
 REGISTRY_BIND_PORT | port to bind to | `8000`

--- a/src/datastore/backends/git.py
+++ b/src/datastore/backends/git.py
@@ -11,6 +11,7 @@ from threading import RLock
 from typing import Any, TypeVar, cast
 
 from dulwich import porcelain
+from dulwich.errors import GitProtocolError, HangupException, SendPackError
 from dulwich.refs import Ref
 from dulwich.repo import Repo
 
@@ -116,14 +117,18 @@ class GitBackend:
 
         self.repo_path.parent.mkdir(parents=True, exist_ok=True)
         if self.remote_url:
-            porcelain.clone(
-                self.remote_url,
-                str(self.repo_path),
-                checkout=True,
-                branch=self.branch,
-                origin="origin",
-                errstream=io.BytesIO(),
-                **self._auth_kwargs(),
+            remote_url = self.remote_url
+            self._run_remote_operation(
+                "clone",
+                lambda: porcelain.clone(
+                    remote_url,
+                    str(self.repo_path),
+                    checkout=True,
+                    branch=self.branch,
+                    origin="origin",
+                    errstream=io.BytesIO(),
+                    **self._auth_kwargs(),
+                ),
             )
         else:
             self.repo_path.mkdir(parents=True, exist_ok=True)
@@ -154,13 +159,16 @@ class GitBackend:
         if not force and self.fetch_ttl_seconds > 0 and now - self._last_fetch_at < self.fetch_ttl_seconds:
             return
 
-        porcelain.fetch(
-            str(self.repo_path),
-            remote_location,
-            outstream=io.StringIO(),
-            errstream=io.BytesIO(),
-            quiet=True,
-            **self._auth_kwargs(),
+        self._run_remote_operation(
+            "fetch",
+            lambda: porcelain.fetch(
+                str(self.repo_path),
+                remote_location,
+                outstream=io.StringIO(),
+                errstream=io.BytesIO(),
+                quiet=True,
+                **self._auth_kwargs(),
+            ),
         )
 
         repo = self._repo()
@@ -178,13 +186,16 @@ class GitBackend:
         if remote_location is None:
             return True
 
-        result = porcelain.push(
-            str(self.repo_path),
-            remote_location,
-            refspecs=f"refs/heads/{self.branch}:refs/heads/{self.branch}",
-            outstream=io.BytesIO(),
-            errstream=io.BytesIO(),
-            **self._auth_kwargs(),
+        result = self._run_remote_operation(
+            "push",
+            lambda: porcelain.push(
+                str(self.repo_path),
+                remote_location,
+                refspecs=f"refs/heads/{self.branch}:refs/heads/{self.branch}",
+                outstream=io.BytesIO(),
+                errstream=io.BytesIO(),
+                **self._auth_kwargs(),
+            ),
         )
         statuses = result.ref_status or {}
         if any(status is not None for status in statuses.values()):
@@ -302,6 +313,27 @@ class GitBackend:
 
     def _repo(self) -> Repo:
         return Repo(str(self.repo_path))
+
+    def _run_remote_operation(self, action: str, operation: Callable[[], _T]) -> _T:
+        try:
+            return operation()
+        except (HangupException, GitProtocolError, SendPackError, OSError) as exc:
+            raise RuntimeError(self._remote_error_message(action)) from exc
+
+    def _remote_error_message(self, action: str) -> str:
+        remote = self.remote_url or "origin"
+        message = [
+            f"Git backend failed to {action} remote {remote!r} for branch {self.branch!r}.",
+        ]
+        if self.remote_url and self.remote_url.startswith("git@"):
+            message.append("Check SSH auth: ensure REGISTRY_BACKEND_GIT_SSH_KEY_PATH points to a readable private key.")
+            message.append(
+                "On Fly, set REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY and add the matching public key "
+                "to the data repository as a deploy key with write access."
+            )
+        else:
+            message.append("Check remote connectivity and credentials.")
+        return " ".join(message)
 
     def _auth_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}

--- a/src/datastore/backends/git.py
+++ b/src/datastore/backends/git.py
@@ -31,6 +31,7 @@ from lib.logging import logger
 
 _T = TypeVar("_T")
 _RETRY = object()
+_UNSET = object()
 
 
 class GitBackend:
@@ -63,17 +64,19 @@ class GitBackend:
         self._lock = RLock()
         self._lock_path = self.repo_path.parent / f".{self.repo_path.name}.lock"
         self._last_fetch_at = 0.0
+        self._origin_remote_url_cache: str | None | object = _UNSET
 
         with self._operation_lock():
             self._ensure_repo_exists()
             self._ensure_branch_symbolic_head()
             self._sync_from_remote(force=True)
             repo = self._repo()
+            _, remote_label, _ = self._resolved_remote(repo)
             logger.info(
                 "Git backend ready: repo=%s branch=%s remote=%s lock=%s fetch_ttl=%ss",
                 self.repo_path,
                 self.branch,
-                self._remote_label(repo),
+                remote_label,
                 self._lock_path,
                 self.fetch_ttl_seconds,
             )
@@ -154,19 +157,21 @@ class GitBackend:
 
     def _sync_from_remote(self, *, force: bool) -> None:
         repo = self._repo()
-        remote_location = self._remote_location(repo)
+        remote_location, remote_label, remote_url = self._resolved_remote(repo)
         if remote_location is None:
             self._last_fetch_at = time.monotonic()
             return
 
         now = time.monotonic()
         if not force and self.fetch_ttl_seconds > 0 and now - self._last_fetch_at < self.fetch_ttl_seconds:
+            logger.debug("Skipping git fetch for %s; within fetch TTL (%ss)", remote_label, self.fetch_ttl_seconds)
             return
 
+        logger.debug("Fetching git remote %s for branch %s", remote_label, self.branch)
         self._run_remote_operation(
             "fetch",
-            remote_label=self._remote_label(repo),
-            remote_url=self._remote_url_for_location(repo, remote_location),
+            remote_label=remote_label,
+            remote_url=remote_url,
             operation=lambda: porcelain.fetch(
                 str(self.repo_path),
                 remote_location,
@@ -183,19 +188,21 @@ class GitBackend:
             repo.refs[self._branch_ref] = target
             repo.refs.set_symbolic_ref(self._head_ref, self._branch_ref)
             porcelain.reset(str(self.repo_path), mode="hard", treeish=target)
+            logger.debug("Updated local branch %s to remote target %s", self.branch, target.hex())
 
         self._last_fetch_at = now
 
     def _push_branch(self) -> bool:
         repo = self._repo()
-        remote_location = self._remote_location(repo)
+        remote_location, remote_label, remote_url = self._resolved_remote(repo)
         if remote_location is None:
             return True
 
+        logger.debug("Pushing git branch %s to %s", self.branch, remote_label)
         result = self._run_remote_operation(
             "push",
-            remote_label=self._remote_label(repo),
-            remote_url=self._remote_url_for_location(repo, remote_location),
+            remote_label=remote_label,
+            remote_url=remote_url,
             operation=lambda: porcelain.push(
                 str(self.repo_path),
                 remote_location,
@@ -207,10 +214,12 @@ class GitBackend:
         )
         statuses = result.ref_status or {}
         if any(status is not None for status in statuses.values()):
+            logger.debug("Git push to %s was rejected; refreshing from remote before retry", remote_label)
             self._sync_from_remote(force=True)
             return False
 
         self._last_fetch_at = time.monotonic()
+        logger.debug("Git push to %s succeeded", remote_label)
         return True
 
     def _save_once(
@@ -307,7 +316,20 @@ class GitBackend:
         )
 
     def _commit_message(self, action: str, rel_path: str) -> bytes:
-        return f"radio-pad-registry: {action} {rel_path}".encode()
+        summary = f"radio-pad-registry: {action} {self._commit_target(rel_path)}"
+        return f"{summary}\n\nGenerated-by: radio-pad-registry".encode()
+
+    def _commit_target(self, rel_path: str) -> str:
+        parts = Path(rel_path).parts
+        if len(parts) == 2 and parts[0] == "accounts":
+            return f"account {Path(parts[1]).stem}"
+        if len(parts) == 4 and parts[0] == "accounts" and parts[2] == "players":
+            return f"player {parts[1]}/{Path(parts[3]).stem}"
+        if len(parts) == 4 and parts[0] == "accounts" and parts[2] == "presets":
+            return f"account preset {parts[1]}/{Path(parts[3]).stem}"
+        if len(parts) == 2 and parts[0] == "presets":
+            return f"global preset {Path(parts[1]).stem}"
+        return rel_path
 
     def _remote_location(self, repo: Repo) -> str | None:
         if self.remote_url == "":
@@ -316,13 +338,13 @@ class GitBackend:
             return "origin"
         return self.remote_url
 
-    def _remote_label(self, repo: Repo) -> str:
+    def _resolved_remote(self, repo: Repo) -> tuple[str | None, str, str | None]:
         remote_location = self._remote_location(repo)
         if remote_location is None:
-            return "disabled"
+            return None, "disabled", None
         if remote_location == "origin":
-            return "origin"
-        return self._display_remote(remote_location)
+            return "origin", "origin", self._origin_remote_url(repo)
+        return remote_location, self._display_remote(remote_location), remote_location
 
     def _repo(self) -> Repo:
         return Repo(str(self.repo_path))
@@ -360,14 +382,17 @@ class GitBackend:
             message.append("Check remote connectivity and credentials.")
         return " ".join(message)
 
-    def _remote_url_for_location(self, repo: Repo, remote_location: str | None) -> str | None:
-        if remote_location != "origin":
-            return remote_location
+    def _origin_remote_url(self, repo: Repo) -> str | None:
+        if self._origin_remote_url_cache is not _UNSET:
+            return cast(str | None, self._origin_remote_url_cache)
         try:
             remote_url = repo.get_config_stack().get((b"remote", b"origin"), b"url")
         except KeyError:
+            self._origin_remote_url_cache = None
             return None
-        return remote_url.decode() if isinstance(remote_url, bytes) else str(remote_url)
+        resolved = remote_url.decode() if isinstance(remote_url, bytes) else str(remote_url)
+        self._origin_remote_url_cache = resolved
+        return resolved
 
     def _display_remote(self, remote_url: str) -> str:
         if "://" in remote_url:

--- a/src/datastore/backends/git.py
+++ b/src/datastore/backends/git.py
@@ -299,7 +299,7 @@ class GitBackend:
         )
 
     def _commit_message(self, action: str, rel_path: str) -> bytes:
-        return f"{action.title()} {rel_path}".encode()
+        return f"radio-pad-registry: {action} {rel_path}".encode()
 
     def _remote_location(self, repo: Repo) -> str | None:
         if self.remote_url == "":

--- a/src/datastore/backends/git.py
+++ b/src/datastore/backends/git.py
@@ -9,8 +9,10 @@ from contextlib import contextmanager
 from pathlib import Path
 from threading import RLock
 from typing import Any, TypeVar, cast
+from urllib.parse import urlsplit, urlunsplit
 
 from dulwich import porcelain
+from dulwich.client import SSHGitClient, get_transport_and_path
 from dulwich.errors import GitProtocolError, HangupException, SendPackError
 from dulwich.refs import Ref
 from dulwich.repo import Repo
@@ -120,7 +122,9 @@ class GitBackend:
             remote_url = self.remote_url
             self._run_remote_operation(
                 "clone",
-                lambda: porcelain.clone(
+                remote_label=self._display_remote(remote_url),
+                remote_url=remote_url,
+                operation=lambda: porcelain.clone(
                     remote_url,
                     str(self.repo_path),
                     checkout=True,
@@ -161,7 +165,9 @@ class GitBackend:
 
         self._run_remote_operation(
             "fetch",
-            lambda: porcelain.fetch(
+            remote_label=self._remote_label(repo),
+            remote_url=self._remote_url_for_location(repo, remote_location),
+            operation=lambda: porcelain.fetch(
                 str(self.repo_path),
                 remote_location,
                 outstream=io.StringIO(),
@@ -188,7 +194,9 @@ class GitBackend:
 
         result = self._run_remote_operation(
             "push",
-            lambda: porcelain.push(
+            remote_label=self._remote_label(repo),
+            remote_url=self._remote_url_for_location(repo, remote_location),
+            operation=lambda: porcelain.push(
                 str(self.repo_path),
                 remote_location,
                 refspecs=f"refs/heads/{self.branch}:refs/heads/{self.branch}",
@@ -309,23 +317,40 @@ class GitBackend:
         return self.remote_url
 
     def _remote_label(self, repo: Repo) -> str:
-        return self._remote_location(repo) or "disabled"
+        remote_location = self._remote_location(repo)
+        if remote_location is None:
+            return "disabled"
+        if remote_location == "origin":
+            return "origin"
+        return self._display_remote(remote_location)
 
     def _repo(self) -> Repo:
         return Repo(str(self.repo_path))
 
-    def _run_remote_operation(self, action: str, operation: Callable[[], _T]) -> _T:
+    def _run_remote_operation(
+        self,
+        action: str,
+        *,
+        remote_label: str,
+        remote_url: str | None,
+        operation: Callable[[], _T],
+    ) -> _T:
         try:
             return operation()
-        except (HangupException, GitProtocolError, SendPackError, OSError) as exc:
-            raise RuntimeError(self._remote_error_message(action)) from exc
+        except (HangupException, GitProtocolError, SendPackError) as exc:
+            raise RuntimeError(self._remote_error_message(action, remote_label, remote_url)) from exc
+        except OSError as exc:
+            message = (
+                f"{self._remote_error_message(action, remote_label, remote_url)} "
+                f"Underlying local error: {exc.__class__.__name__}: {exc}"
+            )
+            raise RuntimeError(message) from exc
 
-    def _remote_error_message(self, action: str) -> str:
-        remote = self.remote_url or "origin"
+    def _remote_error_message(self, action: str, remote_label: str, remote_url: str | None) -> str:
         message = [
-            f"Git backend failed to {action} remote {remote!r} for branch {self.branch!r}.",
+            f"Git backend failed to {action} remote {remote_label!r} for branch {self.branch!r}.",
         ]
-        if self.remote_url and self.remote_url.startswith("git@"):
+        if self._is_ssh_remote(remote_url):
             message.append("Check SSH auth: ensure REGISTRY_BACKEND_GIT_SSH_KEY_PATH points to a readable private key.")
             message.append(
                 "On Fly, set REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY and add the matching public key "
@@ -334,6 +359,45 @@ class GitBackend:
         else:
             message.append("Check remote connectivity and credentials.")
         return " ".join(message)
+
+    def _remote_url_for_location(self, repo: Repo, remote_location: str | None) -> str | None:
+        if remote_location != "origin":
+            return remote_location
+        try:
+            remote_url = repo.get_config_stack().get((b"remote", b"origin"), b"url")
+        except KeyError:
+            return None
+        return remote_url.decode() if isinstance(remote_url, bytes) else str(remote_url)
+
+    def _display_remote(self, remote_url: str) -> str:
+        if "://" in remote_url:
+            return self._redacted_url(remote_url)
+        scp_target = self._scp_style_target(remote_url)
+        if scp_target is not None:
+            return scp_target
+        return remote_url
+
+    def _is_ssh_remote(self, remote_url: str | None) -> bool:
+        if remote_url is None:
+            return self.ssh_key_path is not None
+        try:
+            client, _ = get_transport_and_path(remote_url)
+        except Exception:
+            return False
+        return isinstance(client, SSHGitClient)
+
+    def _redacted_url(self, remote_url: str) -> str:
+        parsed = urlsplit(remote_url)
+        netloc = parsed.hostname or ""
+        if parsed.port is not None:
+            netloc = f"{netloc}:{parsed.port}"
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+    def _scp_style_target(self, remote_url: str) -> str | None:
+        if "@" not in remote_url:
+            return None
+        _, target = remote_url.split("@", 1)
+        return target if ":" in target else None
 
     def _auth_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}

--- a/src/datastore/backends/s3.py
+++ b/src/datastore/backends/s3.py
@@ -10,6 +10,7 @@ from datastore.core import (
     construct_storage_path,
     deconstruct_storage_path,
     normalize_etag,
+    storage_json,
     strip_id,
     validate_if_match,
 )
@@ -107,7 +108,7 @@ class S3Backend:
             if current_hash == new_hash:
                 return
         # Never persist the 'id' field in the JSON content
-        body = json.dumps(to_write, separators=(",", ":"), sort_keys=True, ensure_ascii=False).encode("utf-8")
+        body = storage_json(to_write).encode("utf-8")
         self.client.put_object(Bucket=self.bucket, Key=storage_path, Body=body, Metadata={"rpr-sha256": new_hash})
 
     def delete(self, object_id: str, *path_parts: str) -> bool:

--- a/src/datastore/core/__init__.py
+++ b/src/datastore/core/__init__.py
@@ -5,6 +5,7 @@ from .helpers import (
     deconstruct_storage_path,
     extract_object_id_from_path,
     normalize_etag,
+    storage_json,
     strip_id,
     validate_if_match,
 )
@@ -24,6 +25,7 @@ __all__ = [
     "extract_object_id_from_path",
     "normalize_etag",
     "seedable",
+    "storage_json",
     "strip_id",
     "validate_if_match",
 ]

--- a/src/datastore/core/helpers.py
+++ b/src/datastore/core/helpers.py
@@ -18,6 +18,11 @@ def canonical_json(data: JsonDoc) -> str:
     return json.dumps(data, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
 
 
+def storage_json(data: JsonDoc) -> str:
+    """Return a stable, human-editable JSON string for persisted documents."""
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
 def compute_etag(data: JsonDoc) -> str:
     """Compute a SHA-256 hex digest over the canonical JSON representation."""
     payload = canonical_json(data).encode("utf-8")
@@ -64,8 +69,7 @@ def atomic_write_json_file(path: Path, data: JsonDoc) -> None:
             delete=False,
         ) as f:
             tmp_path = Path(f.name)
-            json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
-            f.write("\n")
+            f.write(storage_json(data))
         os.replace(tmp_path, path)
     finally:
         if tmp_path is not None and tmp_path.exists():

--- a/src/datastore/core/helpers.py
+++ b/src/datastore/core/helpers.py
@@ -64,7 +64,8 @@ def atomic_write_json_file(path: Path, data: JsonDoc) -> None:
             delete=False,
         ) as f:
             tmp_path = Path(f.name)
-            json.dump(data, f, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+            json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
+            f.write("\n")
         os.replace(tmp_path, path)
     finally:
         if tmp_path is not None and tmp_path.exists():

--- a/tests/datastore/backends/test_git.py
+++ b/tests/datastore/backends/test_git.py
@@ -120,6 +120,23 @@ def test_git_backend_clone_error_explains_deploy_key_setup(tmp_path: Path, monke
     assert "deploy key with write access" in message
 
 
+def test_git_backend_clone_error_redacts_remote_credentials(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def failing_clone(*args: object, **kwargs: object) -> None:
+        raise HangupException
+
+    monkeypatch.setattr(porcelain, "clone", failing_clone)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _backend(
+            tmp_path / "clone",
+            remote_url="https://token@github.com/briceburg/radio-pad-registry-data.git",
+        )
+
+    message = str(excinfo.value)
+    assert "token@" not in message
+    assert "https://github.com/briceburg/radio-pad-registry-data.git" in message
+
+
 def test_git_backend_refreshes_reads_from_remote(tmp_path: Path) -> None:
     remote = _create_remote_with_seed(tmp_path)
     backend_path, writer_path = _clone_pair(tmp_path, remote, "backend", "writer")
@@ -131,6 +148,43 @@ def test_git_backend_refreshes_reads_from_remote(tmp_path: Path) -> None:
 
     data, _ = backend.get("fetched", "accounts")
     assert data == {"name": "Fetched"}
+
+
+def test_git_backend_origin_ssh_remote_uses_ssh_guidance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    remote = _create_remote_with_seed(tmp_path)
+    (backend_path,) = _clone_pair(tmp_path, remote, "backend")
+
+    repo = Repo(str(backend_path))
+    config = repo.get_config()
+    config.set((b"remote", b"origin"), b"url", b"ssh://git@github.com/briceburg/radio-pad-registry-data.git")
+    config.write_to_path()
+
+    def failing_fetch(*args: object, **kwargs: object) -> None:
+        raise HangupException
+
+    monkeypatch.setattr(porcelain, "fetch", failing_fetch)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _backend(backend_path)
+
+    assert "REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY" in str(excinfo.value)
+
+
+def test_git_backend_clone_oserror_reports_underlying_local_problem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def failing_clone(*args: object, **kwargs: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(porcelain, "clone", failing_clone)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _backend(
+            tmp_path / "clone",
+            remote_url="git@github.com:briceburg/radio-pad-registry-data.git",
+        )
+
+    assert "Underlying local error: OSError: permission denied" in str(excinfo.value)
 
 
 def test_git_backend_writes_pretty_json_and_clear_commit_subject(tmp_path: Path) -> None:

--- a/tests/datastore/backends/test_git.py
+++ b/tests/datastore/backends/test_git.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import pytest
 from dulwich import porcelain
+from dulwich.errors import HangupException
 from dulwich.refs import Ref
 from dulwich.repo import Repo
 
@@ -99,6 +100,23 @@ def test_git_backend_clones_remote_and_reads_seed_data(tmp_path: Path) -> None:
     data, version = backend.get("seed", "accounts")
     assert data == {"name": "Seed"}
     assert isinstance(version, str) and version
+
+
+def test_git_backend_clone_error_explains_deploy_key_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def failing_clone(*args: object, **kwargs: object) -> None:
+        raise HangupException
+
+    monkeypatch.setattr(porcelain, "clone", failing_clone)
+
+    with pytest.raises(RuntimeError, match="failed to clone remote") as excinfo:
+        _backend(
+            tmp_path / "clone",
+            remote_url="git@github.com:briceburg/radio-pad-registry-data.git",
+        )
+
+    message = str(excinfo.value)
+    assert "REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY" in message
+    assert "deploy key with write access" in message
 
 
 def test_git_backend_refreshes_reads_from_remote(tmp_path: Path) -> None:

--- a/tests/datastore/backends/test_git.py
+++ b/tests/datastore/backends/test_git.py
@@ -208,7 +208,7 @@ def test_git_backend_writes_pretty_json_and_clear_commit_subject(tmp_path: Path)
 
     repo = Repo(str(repo_path))
     commit = cast(Commit, repo[repo.head()])
-    assert commit.message == b"radio-pad-registry: update presets/fresh.json"
+    assert commit.message == (b"radio-pad-registry: update global preset fresh\n\nGenerated-by: radio-pad-registry")
 
 
 def test_git_backend_detects_stale_if_match_after_remote_change(tmp_path: Path) -> None:

--- a/tests/datastore/backends/test_git.py
+++ b/tests/datastore/backends/test_git.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 import pytest
 from dulwich import porcelain
 from dulwich.errors import HangupException
+from dulwich.objects import Commit
 from dulwich.refs import Ref
 from dulwich.repo import Repo
 
@@ -130,6 +131,30 @@ def test_git_backend_refreshes_reads_from_remote(tmp_path: Path) -> None:
 
     data, _ = backend.get("fetched", "accounts")
     assert data == {"name": "Fetched"}
+
+
+def test_git_backend_writes_pretty_json_and_clear_commit_subject(tmp_path: Path) -> None:
+    repo_path = tmp_path / "repo"
+    _init_repo(repo_path)
+
+    backend = _backend(repo_path)
+    backend.save("fresh", {"name": "Fresh", "stations": [{"url": "https://example.com", "name": "Example"}]}, "presets")
+
+    assert (repo_path / "presets" / "fresh.json").read_text(encoding="utf-8") == (
+        "{\n"
+        '  "name": "Fresh",\n'
+        '  "stations": [\n'
+        "    {\n"
+        '      "name": "Example",\n'
+        '      "url": "https://example.com"\n'
+        "    }\n"
+        "  ]\n"
+        "}\n"
+    )
+
+    repo = Repo(str(repo_path))
+    commit = cast(Commit, repo[repo.head()])
+    assert commit.message == b"radio-pad-registry: update presets/fresh.json"
 
 
 def test_git_backend_detects_stale_if_match_after_remote_change(tmp_path: Path) -> None:

--- a/tests/datastore/backends/test_s3.py
+++ b/tests/datastore/backends/test_s3.py
@@ -9,6 +9,7 @@ import pytest
 from moto import mock_aws
 
 from datastore.backends.s3 import S3Backend
+from datastore.core import storage_json
 
 
 @pytest.fixture
@@ -63,3 +64,12 @@ class TestS3BackendListFiltering:
         # Path with only nested objects (no direct children)
         s3_backend.save("nested", {"name": "Nested"}, "path", "deep", "nested")
         assert s3_backend.list("path") == []
+
+    def test_save_uses_shared_storage_json_format(self, s3_backend: S3Backend) -> None:
+        payload = {"z": 1, "nested": {"b": 2, "a": 1}, "name": "Briceburg"}
+        s3_backend.save("briceburg", payload, "accounts")
+
+        obj = s3_backend.client.get_object(Bucket=s3_backend.bucket, Key="test/accounts/briceburg.json")
+        body = obj["Body"].read().decode("utf-8")
+
+        assert body == storage_json(payload)

--- a/tests/datastore/test_helpers.py
+++ b/tests/datastore/test_helpers.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from datastore.core import atomic_write_json_file
+
+
+def test_atomic_write_json_file_pretty_formats_json(tmp_path: Path) -> None:
+    target = tmp_path / "example.json"
+
+    atomic_write_json_file(
+        target,
+        {
+            "z": 1,
+            "nested": {"b": 2, "a": 1},
+            "name": "Briceburg",
+        },
+    )
+
+    assert target.read_text(encoding="utf-8") == (
+        '{\n  "name": "Briceburg",\n  "nested": {\n    "a": 1,\n    "b": 2\n  },\n  "z": 1\n}\n'
+    )


### PR DESCRIPTION
## Summary

This PR improves the Git-backed registry workflow in a few practical ways:

- surfaces clearer startup errors when Dulwich cannot authenticate to the Git remote
- fixes the README deploy-key instructions so GitHub and Fly receive the correct halves of the SSH keypair
- makes registry-managed commits easier to recognize in the data repository history
- pretty-formats stored JSON across backends so persisted documents are easier to read and edit by hand

## Changes

- Wrap Git remote `clone` / `fetch` / `push` failures with an actionable error message.
- For SSH remotes, the error now points operators to:
  - `REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY`
  - `REGISTRY_BACKEND_GIT_SSH_KEY_PATH`
  - adding the matching public key to the data repo as a write-enabled deploy key
- Clarify Fly deployment docs so:
  - `~/.ssh/... .pub` goes to GitHub as the deploy key
  - the private key contents go to Fly as `REGISTRY_BACKEND_GIT_SSH_PRIVATE_KEY`
- Change Git-backed commit subjects to identify registry-managed writes, e.g. `radio-pad-registry: update presets/foo.json`.
- Introduce a shared storage JSON renderer and use it across local, Git, and S3-backed document persistence so stored documents are consistently pretty-printed with sorted keys and indentation.
- Keep ETag computation based on canonical compact JSON so concurrency tokens reflect semantic content rather than formatting.
- Document that `REGISTRY_BACKEND_GIT_AUTHOR_EMAIL` should use a GitHub-linked address if commit attribution to a GitHub user is desired.
- Add regression coverage for the clone/auth failure path and shared JSON formatting behavior.

## Validation

- `bin/ci`
- `pytest tests/datastore/backends/test_git.py tests/datastore/backends/test_s3.py tests/datastore/test_helpers.py`
- `pytest`
